### PR TITLE
Make the popup a rickroll

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,10 @@
     "48": "/icons/icon48.png",
     "128": "/icons/icon128.png"
   },
+  
+  "browser_action": {
+    "default_popup": "popup.html",
+  },
 
   "content_scripts": [
     {


### PR DESCRIPTION
I have done some very interesting research and have found quite a lot of strong evidence to lead me to believe what I am about to state.

According to [something written](https://grouplens.org/blog/how-many-americans-have-been-rickrolled/) by the most random guy named Reid on the most random social media website, about 18 million Americans have been rickrolled. 18 MILLION. Wow.

There are 329.5 million people in the United States, and so 18 million is simply a small fraction of that. This is truly unacceptable, which is why I appreciate subtle extensions such as this one. I just can't handle knowing that there are over 300 million Americans who still haven't been rickrolled, and so I feel obligated to do something about it.

I feel that it is very important to add a popup to the rickroll, using the same popup that is used when a user visits a webpage. This popup would be opened when you click on the extension's icon, and, like when a new page is opened, will immediately start playing a rickroll.